### PR TITLE
Alternative link for pypdflib and added Pillow

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,10 @@ setup(
     include_package_data=True,
     setup_requires=['setuptools-git'],
     test_suite='tests',
-    install_requires=['setuptools', 'hyphenation', 'pypdflib', 'pyquery','PIL'],
+    install_requires=['setuptools',
+                      'hyphenation',
+                      'https://github.com/Project-SILPA/pypdflib',
+                      'pyquery',
+                      'Pillow'],
     zip_safe=False,
 )


### PR DESCRIPTION
@jishnu7, Added github link for pypdflib as it is not available from pip
Also added Pillow as an alternative for PIL