### PR TITLE
Fix install_requires error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,10 @@ setup(
     test_suite='tests',
     install_requires=['setuptools',
                       'hyphenation',
-                      'https://github.com/Project-SILPA/pypdflib',
-                      'pyquery',
-                      'Pillow'],
+                      'pypdflib',
+                      'pyquery'],
+    dependency_links=[
+        'git+https://github.com/libindic/pypdflib#egg=pypdflib-0.1.a3'
+    ],
     zip_safe=False,
 )


### PR DESCRIPTION
Adds a dependency link from which pydflib will be installed. Pillow
has been removed as it is a dependecy for pypdflib itself.